### PR TITLE
Embedded into profile and other things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Next Release
 
 Misc
 ----
+* [#57](https://github.com/grgrzybek/tomcat-slf4j-logback/pull/57): Embedded breakout [@hazendaz](https://github.com/hazendaz).
+  * Embedded support was listed mixed throughout and commented out.  Now it is a profile as 'embedded'
+
 * [#33](https://github.com/grgrzybek/tomcat-slf4j-logback/pull/33): Merged Maven to Master [@hazendaz](https://github.com/hazendaz).
   * Maven build merged to master removing prior ant/ivy build
 

--- a/pom.xml
+++ b/pom.xml
@@ -110,8 +110,6 @@
         <tomcat7.version>7.0.59</tomcat7.version>
         <tomcat8.version>8.0.18</tomcat8.version>
         <tomcat.version>${tomcat8.version}</tomcat.version>
-
-        <git.commit.id />
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -492,7 +492,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.9</version>
+                    <version>2.10</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -121,11 +121,6 @@
             <dependencies>
                 <dependency>
                     <groupId>org.apache.tomcat</groupId>
-                    <artifactId>catalina</artifactId>
-                    <version>${tomcat6.version}</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.tomcat</groupId>
                     <artifactId>juli</artifactId>
                     <version>${tomcat6.version}</version>
                 </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -234,46 +234,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <configuration>
-                            <descriptor>${project.basedir}/src/assembly/assembly-tomcat6.xml</descriptor>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>make-assembly</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-jar-plugin</artifactId>
-                        <configuration>
-                            <archive>
-                                <manifest>
-                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                                    <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                                </manifest>
-                                <manifestEntries>
-                                    <Build-Time>${maven.build.timestamp}</Build-Time>
-                                    <Git-Revision>${git.commit.id}</Git-Revision>
-                                    <Tomcat-Classloader-Version>${tomcat6.version}</Tomcat-Classloader-Version>
-                                    <Slf4j-Version>${slf4j.version}</Slf4j-Version>
-                                    <Logback-Version>${logback-for-tomcat6.version}</Logback-Version>
-                                    <Os-Name>${os.name}</Os-Name>
-                                    <Os-Arch>${os.arch}</Os-Arch>
-                                    <Os-Version>${os.version}</Os-Version>
-                                    <X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>
-                                    <X-Compile-Target-JDK>${maven.compiler.target}</X-Compile-Target-JDK>
-                                </manifestEntries>
-                            </archive>
-                        </configuration>
-                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -404,43 +364,13 @@
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <configuration>
-                            <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
-                        </configuration>
                         <executions>
                             <execution>
-                                <id>make-assembly</id>
                                 <phase>package</phase>
                                 <goals>
-                                    <goal>single</goal>
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-jar-plugin</artifactId>
-                        <configuration>
-                            <archive>
-                                <manifest>
-                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                                    <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                                </manifest>
-                                <manifestEntries>
-                                    <Build-Time>${maven.build.timestamp}</Build-Time>
-                                    <Git-Revision>${git.commit.id}</Git-Revision>
-                                    <Tomcat-Classloader-Version>${tomcat.version}</Tomcat-Classloader-Version>
-                                    <Slf4j-Version>${slf4j.version}</Slf4j-Version>
-                                    <Logback-Version>${logback.version}</Logback-Version>
-                                    <Os-Name>${os.name}</Os-Name>
-                                    <Os-Arch>${os.arch}</Os-Arch>
-                                    <Os-Version>${os.version}</Os-Version>
-                                    <X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>
-                                    <X-Compile-Target-JDK>${maven.compiler.target}</X-Compile-Target-JDK>
-                                </manifestEntries>
-                            </archive>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -607,6 +537,22 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
                 <configuration>
                     <excludeDefaultDirectories>true</excludeDefaultDirectories>
@@ -687,6 +633,31 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <Build-Time>${maven.build.timestamp}</Build-Time>
+                            <!-- Git Commit Id property is auto generated -->
+                            <Git-Revision>${git.commit.id}</Git-Revision>
+                            <Tomcat-Classloader-Version>${tomcat.version}</Tomcat-Classloader-Version>
+                            <Slf4j-Version>${slf4j.version}</Slf4j-Version>
+                            <Logback-Version>${logback.version}</Logback-Version>
+                            <Os-Name>${os.name}</Os-Name>
+                            <Os-Arch>${os.arch}</Os-Arch>
+                            <Os-Version>${os.version}</Os-Version>
+                            <X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>
+                            <X-Compile-Target-JDK>${maven.compiler.target}</X-Compile-Target-JDK>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -634,7 +634,7 @@
                         <dependency>
                             <groupId>org.eclipse.jgit</groupId>
                             <artifactId>org.eclipse.jgit</artifactId>
-                            <version>3.6.1.201501031845-r</version>
+                            <version>3.6.2.201501210735-r</version>
                         </dependency>
                         <dependency>
                             <groupId>org.codehaus.plexus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,6 @@
                                     <shadeSourcesContent>true</shadeSourcesContent>
                                     <artifactSet>
                                         <includes>
-                                            <!-- For tomcat juli -->
                                             <include>org.apache.tomcat:juli</include>
 
                                             <include>org.slf4j:jcl-over-slf4j</include>
@@ -177,7 +176,6 @@
                                         </includes>
                                     </artifactSet>
                                     <filters>
-                                        <!-- For tomcat juli -->
                                         <filter>
                                             <artifact>org.apache.tomcat:juli</artifact>
                                             <includes>
@@ -293,14 +291,6 @@
                     <artifactId>tomcat-juli</artifactId>
                     <version>${tomcat.version}</version>
                 </dependency>
-                <!-- For embedded tomcat juli -->
-                <!--
-                <dependency>
-                    <groupId>org.apache.tomcat.embed</groupId>
-                    <artifactId>tomcat-embed-logging-juli</artifactId>
-                    <version>${tomcat.version}</version>
-                </dependency>
-                -->
                 <dependency>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
@@ -344,11 +334,7 @@
                                     <shadeSourcesContent>true</shadeSourcesContent>
                                     <artifactSet>
                                         <includes>
-                                            <!-- For tomcat juli -->
                                             <include>org.apache.tomcat:tomcat-juli</include>
-
-                                            <!-- For embedded tomcat juli -->
-                                            <!-- <include>org.apache.tomcat.embed:tomcat-embed-logging-juli</include> -->
 
                                             <include>org.slf4j:jcl-over-slf4j</include>
                                             <include>org.slf4j:slf4j-api</include>
@@ -357,7 +343,6 @@
                                         </includes>
                                     </artifactSet>
                                     <filters>
-                                        <!-- For tomcat juli -->
                                         <filter>
                                             <artifact>org.apache.tomcat:tomcat-juli</artifact>
                                             <includes>
@@ -367,18 +352,6 @@
                                                 <include>META-INF/NOTICE</include>
                                             </includes>
                                         </filter>
-
-                                        <!-- For embedded tomcat juli -->
-                                        <!--
-                                        <filter>
-                                            <artifact>org.apache.tomcat.embed:tomcat-embed-logging-juli</artifact>
-                                            <includes>
-                                                <include>org/apache/juli/ClassLoaderLogManager**</include>
-                                                <include>META-INF/LICENSE</include>
-                                                <include>META-INF/NOTICE</include>
-                                            </includes>
-                                        </filter>
-                                        -->
 
                                         <filter>
                                             <artifact>org.slf4j:jcl-over-slf4j</artifact>
@@ -475,11 +448,7 @@
     </profiles>
 
     <build>
-        <!-- For tomcat juli -->
         <finalName>tomcat-juli</finalName>
-
-        <!-- For embedded tomcat juli -->
-        <!-- <finalName>tomcat-embed-logging-juli</finalName> -->
 
         <pluginManagement>
             <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -587,21 +587,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.github.github</groupId>
-                <artifactId>site-maven-plugin</artifactId>
-                <configuration>
-                    <message>Creating site for ${project.version}</message>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>site</goal>
-                        </goals>
-                        <phase>site</phase>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <configuration>
@@ -658,6 +643,21 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <configuration>
+                    <message>Creating site for ${project.version}</message>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>site</goal>
+                        </goals>
+                        <phase>site</phase>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.grgrzybek</groupId>
     <artifactId>tomcat-slf4j-logback</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 
     <name>tomcat-slf4j-logback</name>
     <description>Tomcat Slf4j Logback Integration</description>
@@ -107,6 +107,7 @@
         <logback-for-tomcat6.version>0.9.30</logback-for-tomcat6.version>
         <slf4j.version>1.7.10</slf4j.version>
 
+        <tomcat6.version>6.0.43</tomcat6.version>
         <tomcat7.version>7.0.59</tomcat7.version>
         <tomcat8.version>8.0.18</tomcat8.version>
         <tomcat.version>${tomcat8.version}</tomcat.version>

--- a/pom.xml
+++ b/pom.xml
@@ -103,14 +103,14 @@
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <logback.version>1.1.2</logback.version>
+        <logback.version>1.1.3</logback.version>
         <logback-for-tomcat6.version>0.9.30</logback-for-tomcat6.version>
-        <slf4j.version>1.7.10</slf4j.version>
+        <slf4j.version>1.7.12</slf4j.version>
 
         <tomcat6.version>6.0.43</tomcat6.version>
         <tomcat7.version>7.0.59</tomcat7.version>
-        <tomcat8.version>8.0.18</tomcat8.version>
-        <tomcat.version>${tomcat8.version}</tomcat.version>
+        <tomcat8.version>8.0.21</tomcat8.version>
+        <tomcat.version>${tomcat6.version}</tomcat.version>
     </properties>
 
     <profiles>
@@ -487,7 +487,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.2</version>
+                    <version>3.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -512,12 +512,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>2.6</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.1</version>
+                    <version>2.10.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -595,7 +595,7 @@
                         <dependency>
                             <groupId>com.googlecode.javaewah</groupId>
                             <artifactId>JavaEWAH</artifactId>
-                            <version>1.0.0</version>
+                            <version>1.0.2</version>
                         </dependency>
                         <dependency>
                             <groupId>com.jcraft</groupId>
@@ -605,12 +605,12 @@
                         <dependency>
                             <groupId>org.eclipse.jgit</groupId>
                             <artifactId>org.eclipse.jgit</artifactId>
-                            <version>3.6.2.201501210735-r</version>
+                            <version>3.7.0.201502260915-r</version>
                         </dependency>
                         <dependency>
                             <groupId>org.codehaus.plexus</groupId>
                             <artifactId>plexus-utils</artifactId>
-                            <version>3.0.21</version>
+                            <version>3.0.22</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,13 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <configuration>
+                            <descriptor>${project.basedir}/src/assembly/assembly-tomcat6.xml</descriptor>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-shade-plugin</artifactId>
                         <executions>
                             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -357,13 +357,100 @@
                             </execution>
                         </executions>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>embedded</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.tomcat.embed</groupId>
+                    <artifactId>tomcat-embed-logging-juli</artifactId>
+                    <version>${tomcat.version}</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <finalName>tomcat-embed-logging-juli</finalName>
+                <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
                         <executions>
                             <execution>
                                 <phase>package</phase>
                                 <goals>
+                                    <goal>shade</goal>
                                 </goals>
+                                <configuration>
+                                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                                    <createSourcesJar>true</createSourcesJar>
+                                    <shadeSourcesContent>true</shadeSourcesContent>
+                                    <artifactSet>
+                                        <includes>
+                                            <include>org.apache.tomcat.embed:tomcat-embed-logging-juli</include>
+
+                                            <include>org.slf4j:jcl-over-slf4j</include>
+                                            <include>org.slf4j:slf4j-api</include>
+                                            <include>ch.qos.logback:logback-classic</include>
+                                            <include>ch.qos.logback:logback-core</include>
+                                        </includes>
+                                    </artifactSet>
+                                    <filters>
+                                        <filter>
+                                            <artifact>org.apache.tomcat.embed:tomcat-embed-logging-juli</artifact>
+                                            <includes>
+                                                <include>org/apache/juli/ClassLoaderLogManager**</include>
+                                                <include>META-INF/LICENSE</include>
+                                                <include>META-INF/NOTICE</include>
+                                            </includes>
+                                        </filter>
+
+                                        <filter>
+                                            <artifact>org.slf4j:jcl-over-slf4j</artifact>
+                                            <excludes>
+                                                <exclude>META-INF/services/**</exclude>
+                                            </excludes>
+                                        </filter>
+                                    </filters>
+                                    <relocations>
+                                        <relocation>
+                                            <pattern>org.apache.commons.logging</pattern>
+                                            <shadedPattern>org.apache.juli.logging</shadedPattern>
+                                        </relocation>
+                                        <relocation>
+                                            <pattern>org.slf4j</pattern>
+                                            <shadedPattern>org.apache.juli.logging.org.slf4j</shadedPattern>
+                                        </relocation>
+                                        <relocation>
+                                            <pattern>ch.qos.logback</pattern>
+                                            <shadedPattern>org.apache.juli.logging.ch.qos.logback</shadedPattern>
+                                        </relocation>
+                                        <!-- Located in org.apache.juli.logging.ch.qos.logback.classic.util -->
+                                        <relocation>
+                                            <pattern>logback.configurationFile</pattern>
+                                            <shadedPattern>juli-logback.configurationFile</shadedPattern>
+                                        </relocation>
+                                        <!-- Located in org.apache.juli.logging.org.slf4j.MarkerFactory -->
+                                        <relocation>
+                                            <pattern>logback.ContextSelector</pattern>
+                                            <shadedPattern>juli-logback.ContextSelector</shadedPattern>
+                                        </relocation>
+                                    </relocations>
+                                    <transformers>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                            <resource>META-INF/LICENSE-logback.txt</resource>
+                                            <file>${project.basedir}/src/assembly/LICENSE-logback.txt</file>
+                                        </transformer>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                            <resource>META-INF/LICENSE-slf4j.txt</resource>
+                                            <file>${project.basedir}/src/assembly/LICENSE-slf4j.txt</file>
+                                        </transformer>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                            <resource>META-INF/services/org.apache.commons.logging.LogFactory</resource>
+                                            <file>${project.basedir}/src/assembly/services/org.apache.commons.logging.LogFactory</file>
+                                        </transformer>
+                                    </transformers>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -587,17 +587,17 @@
                 <plugin>
                     <groupId>pl.project13.maven</groupId>
                     <artifactId>git-commit-id-plugin</artifactId>
-                    <version>2.1.12</version>
+                    <version>2.1.13</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-scm-plugin</artifactId>
-                    <version>1.9.2</version>
+                    <version>1.9.4</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.maven.scm</groupId>
                             <artifactId>maven-scm-provider-jgit</artifactId>
-                            <version>1.9.2</version>
+                            <version>1.9.4</version>
                         </dependency>
                         <dependency>
                             <groupId>com.googlecode.javaewah</groupId>
@@ -607,7 +607,7 @@
                         <dependency>
                             <groupId>com.jcraft</groupId>
                             <artifactId>jsch</artifactId>
-                            <version>0.1.51</version>
+                            <version>0.1.52</version>
                         </dependency>
                         <dependency>
                             <groupId>org.eclipse.jgit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -626,7 +626,7 @@
                 <executions>
                     <execution>
                         <id>make-assembly</id>
-                        <phase>package</phase>
+                        <phase>install</phase>
                         <goals>
                             <goal>single</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<project
-        xmlns="http://maven.apache.org/POM/4.0.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -115,9 +115,6 @@
     <profiles>
         <profile>
             <id>tomcat6</id>
-            <properties>
-                <tomcat6.version>6.0.43</tomcat6.version>
-            </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.apache.tomcat</groupId>
@@ -242,9 +239,6 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <tomcat.version>${tomcat8.version}</tomcat.version>
-            </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.apache.tomcat</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -531,7 +531,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.3.1</version>
+                    <version>1.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/src/assembly/assembly-tomcat6.xml
+++ b/src/assembly/assembly-tomcat6.xml
@@ -25,7 +25,7 @@
     <fileSets>
         <fileSet>
             <directory>${project.basedir}/src/assembly</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory></outputDirectory>
             <includes>
                 <include>LICENSE-logback.txt</include>
                 <include>LICENSE-slf4j.txt</include>

--- a/src/assembly/assembly.xml
+++ b/src/assembly/assembly.xml
@@ -25,7 +25,7 @@
     <fileSets>
         <fileSet>
             <directory>${project.basedir}/src/assembly</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory></outputDirectory>
             <includes>
                 <include>LICENSE-logback.txt</include>
                 <include>LICENSE-slf4j.txt</include>


### PR DESCRIPTION
A number of changes here.  I think I followed all that was being attempted and modified a bit to still go through all that.

question: is tomcat6 vs 7/8 do all the same things except the dependency?  If so, further cleanup can occur.

I fixed the xsd so it doesn't redirect.

I removed 'git.commit.id' and added note that it is auto generated.  Marking it as there actually was causing it to not work.  It's in the manifest.

Plugins moved around so less duplication outside my question.  Embedded is separated out now so easy to create.  I have never tested embedded to verify it is good to go but this makes it easier to finally do that.

It would seem to me that setting tomcat version is only applicable to tomcat 7 or 8 but not 6.  That still is true after my changes.  I was trying to figure out how to make that happen but couldn't pull it off.

Anyway, please advise if this still works as you expect and nothing broken.  If tomcat 6, 7, 8 are all still doing same, I will work to clean it up further.  At that point I will publish the first embedded as I will verify all is working properly.