### PR TITLE
Fix enforcer plugin.  Maven appears to have a bug.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -490,21 +490,19 @@
                             <configuration>
                                 <lifecycleMappingMetadata>
                                     <pluginExecutions>
-                                        <pluginExecutions>
-                                            <pluginExecution>
-                                                <pluginExecutionFilter>
-                                                    <groupId>org.apache.maven.plugins</groupId>
-                                                    <artifactId>maven-enforcer-plugin</artifactId>
-                                                    <versionRange>[1.4,)</versionRange>
-                                                    <goals>
-                                                        <goal>enforce</goal>
-                                                    </goals>
-                                                </pluginExecutionFilter>
-                                                <action>
-                                                    <ignore />
-                                                </action>
-                                            </pluginExecution>
-                                        </pluginExecutions>
+                                        <pluginExecution>
+                                            <pluginExecutionFilter>
+                                                <groupId>org.apache.maven.plugins</groupId>
+                                                <artifactId>maven-enforcer-plugin</artifactId>
+                                                <versionRange>[1.4,)</versionRange>
+                                                <goals>
+                                                    <goal>enforce</goal>
+                                                </goals>
+                                            </pluginExecutionFilter>
+                                            <action>
+                                                <ignore />
+                                            </action>
+                                        </pluginExecution>
                                     </pluginExecutions>
                                 </lifecycleMappingMetadata>
                             </configuration>
@@ -732,6 +730,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
+                <!-- Seems like maven bug when trying to exclude enforce in mapping lifecycle -->
+                <version>1.4</version>
                 <configuration>
                     <rules>
                         <requireMavenVersion>


### PR DESCRIPTION
The OSS parent does not put the version for this plugin in plugin
management.  As a result, it overrides part of what is used.  This in
turn makes it appear as though we are not using the correct version and
we are not partially.  So this trade off warning ensures we have the
same version throughout.