### PR TITLE
Rewrite README for release information without defining versions...

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,9 @@ If you quickly want to configure Tomcat to use Slf4J and Logback, just download 
 from [SourceForge](https://sourceforge.net/projects/tc-slf4jlogback/files/) and explode zip file directly
 into $CATALINA_HOME.  Beware! - doing so will replace server.xml with default version and logging valve.
 
-The latest version (Tomcat 6.0.44, 7.0.62, or 8.0.24, Slf4j 1.7.12, Logback 1.1.3) may be downloaded from
-[SourceForge](https://sourceforge.net/projects/tc-slf4jlogback/files/).  Previous versions are available
-as well.
+Previous versions are available and may be downloaded from [SourceForge](https://sourceforge.net/projects/tc-slf4jlogback/files/)
 
-All future versions will be released on github releases.  The latest versions
-(Tomcat 7.0.67, 8.0.29, 9.0.0.M1, Slf4j 1.7.12 or 1.7.13, Logback 1.1.3) may be downloaded from [releases](https://github.com/grgrzybek/tomcat-slf4j-logback/releases)
+New versions are available and may be downloaded from [releases](https://github.com/grgrzybek/tomcat-slf4j-logback/releases)
 
 Some rather old versions are not predefined for direct exploding into $CATALINA_HOME.
 


### PR DESCRIPTION
because that requires us to keep changing the readme.  The versioneye
tag showing up-to-date is enough to prove we are on latest versions.