### PR TITLE
Bringing in broader support for maven central deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,11 @@ setting `file:` from logback.configurationFile.
 
 ## Maven Central Distribution ##
 
-Maven central distribution is primarily for users building tomcat distributions.  We are still working on this feature.
+Maven central distribution is primarily for users building tomcat distributions.
 
-For developers to release, source jar and zip need deleted on distribution before release can proceed.
+For developers to release
+
+ - mvn deploy -Prelease
 
 For users to get release, use dependency as follows.
 

--- a/pom.xml
+++ b/pom.xml
@@ -778,6 +778,7 @@
                 <artifactId>git-commit-id-plugin</artifactId>
                 <configuration>
                     <dotGitDirectory>.git</dotGitDirectory>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
                     <!-- Fixes occassional issue in commit id plugin - see https://github.com/ktoso/maven-git-commit-id-plugin/issues/61 -->
                     <gitDescribe>
                         <always>true</always>

--- a/pom.xml
+++ b/pom.xml
@@ -638,6 +638,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5.3</version>
+                    <configuration>
+                        <releaseProfiles>release</releaseProfiles>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -539,6 +539,13 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <configuration>
+                            <skipAssembly>true</skipAssembly>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <executions>
                             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,12 @@
     <artifactId>tomcat-slf4j-logback</artifactId>
     <packaging>jar</packaging>
 
+    <!-- Set version when deploying to central -->
+    <version>8.0.36</version>
+
     <!-- <version>6.0.45-SNAPSHOT</version> -->
     <!-- <version>7.0.70-SNAPSHOT</version> -->
-    <version>7.0.70-SNAPSHOT</version>
+    <!-- <version>8.0.36-SNAPSHOT</version> -->
     <!-- <version>8.5.4-SNAPSHOT</version> -->
     <!-- <version>9.0.0.M9-SNAPSHOT</version> -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -591,7 +591,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.5.1</version>
-                   <configuration>
+                    <configuration>
                         <!-- Slightly faster builds, see https://issues.apache.org/jira/browse/MCOMPILER-209 -->
                         <useIncrementalCompilation>false</useIncrementalCompilation>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -853,6 +853,74 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <Build-Time>${maven.build.timestamp}</Build-Time>
+                            <copyright>${copyright}</copyright>
+                            <!-- Git Commit Id property is auto generated -->
+                            <Git-Revision>${git.commit.id}</Git-Revision>
+                            <Tomcat-Classloader-Version>${tomcat.version}</Tomcat-Classloader-Version>
+                            <Slf4j-Version>${slf4j.version}</Slf4j-Version>
+                            <Logback-Version>${logback.version}</Logback-Version>
+                            <Os-Name>${os.name}</Os-Name>
+                            <Os-Arch>${os.arch}</Os-Arch>
+                            <Os-Version>${os.version}</Os-Version>
+                            <X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>
+                            <X-Compile-Target-JDK>${maven.compiler.target}</X-Compile-Target-JDK>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <Build-Time>${maven.build.timestamp}</Build-Time>
+                            <copyright>${copyright}</copyright>
+                            <!-- Git Commit Id property is auto generated -->
+                            <Git-Revision>${git.commit.id}</Git-Revision>
+                            <Tomcat-Classloader-Version>${tomcat.version}</Tomcat-Classloader-Version>
+                            <Slf4j-Version>${slf4j.version}</Slf4j-Version>
+                            <Logback-Version>${logback.version}</Logback-Version>
+                            <Os-Name>${os.name}</Os-Name>
+                            <Os-Arch>${os.arch}</Os-Arch>
+                            <Os-Version>${os.version}</Os-Version>
+                            <X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>
+                            <X-Compile-Target-JDK>${maven.compiler.target}</X-Compile-Target-JDK>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <inceptionYear>2010</inceptionYear>
 
     <prerequisites>
-        <maven>3.1.1</maven>
+        <maven>3.2.5</maven>
     </prerequisites>
 
     <organization>

--- a/src/main/java/com/github/grgrzybek/notice/TomcatSlf4jLogback.java
+++ b/src/main/java/com/github/grgrzybek/notice/TomcatSlf4jLogback.java
@@ -1,0 +1,11 @@
+package com.github.grgrzybek.notice;
+
+/**
+ * Tomcat SLF4J Logback is a drop in replacement to tomcat allowing full all
+ * internal logging to use our favorite slf4j/logback libraries.
+ *
+ * @see <a href="https://github.com/grgrzybek/tomcat-slf4j-logback">https://github.com/grgrzybek/tomcat-slf4j-logback</a>
+ */
+public class TomcatSlf4jLogback {
+    // Marker Class
+}

--- a/src/main/java/com/github/grgrzybek/notice/package-info.java
+++ b/src/main/java/com/github/grgrzybek/notice/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Tomcat SLF4J Logback is a drop in replacement to tomcat allowing full all
+ * internal logging to use our favorite slf4j/logback libraries.
+ */
+package com.github.grgrzybek.notice;


### PR DESCRIPTION
Prior maven central deployment required a number of manual steps.  This has completely been addressed.  Now it's just a normal release.  This required we have valid javadocs and source therefore we have a bit of code that is empty just marking the project.